### PR TITLE
Don't clobber registry information in .npmrc

### DIFF
--- a/Tasks/Yarn/yarnTask.ts
+++ b/Tasks/Yarn/yarnTask.ts
@@ -94,8 +94,11 @@ async function yarnExec() {
         }
 
         for (let registry of npmRegistries) {
-            tl.debug("Using registry: " + registry.url);
-            util.appendToNpmrc(npmrc, `registry=${registry.url}\n`);
+            if (registryLocation === RegistryLocation.Feed) {
+                // Don't clobber existing registry settings when getting registries from .npmrc
+                tl.debug("Using registry: " + registry.url);
+                util.appendToNpmrc(npmrc, `registry=${registry.url}\n`);
+            }
             tl.debug("Adding auth for registry: " + registry.url);
             util.appendToNpmrc(npmrc, `${registry.auth}\n`);
             if (registry.url.indexOf(".visualstudio.com") >= 0) {


### PR DESCRIPTION
When picking up registries from .npmrc, don't replace them. Adding
unqualified registries will break when using multiple, namespaced
registries, as yarn will attempt to use the last registry configured
for all packages.