### PR TITLE
Updating to Azure-Pipelines-Task-Lib

### DIFF
--- a/Tasks/Yarn/package.json
+++ b/Tasks/Yarn/package.json
@@ -3,15 +3,15 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "fs-extra": "4.0.0",
-    "yog-tar.gz": "0.1.3",
     "azure-devops-node-api": "^6.6.0",
+    "azure-pipelines-task-lib": "^2.8.0",
+    "fs-extra": "4.0.0",
     "ini": "^1.3.4",
     "ip-address": "^5.8.9",
     "ltx": "^2.6.2",
     "q": "^1.5.0",
     "typed-rest-client": "0.12.0",
-    "vsts-task-lib": "2.7.0",
-    "vsts-task-tool-lib": "0.10.0"
+    "vsts-task-tool-lib": "0.10.0",
+    "yog-tar.gz": "0.1.3"
   }
 }

--- a/Tasks/Yarn/packaging/locationUtilities.ts
+++ b/Tasks/Yarn/packaging/locationUtilities.ts
@@ -1,6 +1,6 @@
 import * as vsts from 'azure-devops-node-api';
 import * as interfaces from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import { IRequestOptions } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 
 import * as provenance from "./provenance";

--- a/Tasks/Yarn/packaging/util.ts
+++ b/Tasks/Yarn/packaging/util.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
 
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 
 export function getTempPath(): string {
     const tempNpmrcDir

--- a/Tasks/Yarn/yarn.lock
+++ b/Tasks/Yarn/yarn.lock
@@ -25,6 +25,18 @@ azure-devops-node-api@^6.6.0:
     typed-rest-client "1.0.9"
     underscore "1.8.3"
 
+azure-pipelines-task-lib@^2.8.0:
+  version "2.8.0"
+  resolved "https://www.myget.org/F/gl-unstable/npm/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz#8a0117a98f86c2e9ee85333e649874bf83ccb836"
+  integrity sha1-igEXqY+GwunuhTM+ZJh0v4PMuDY=
+  dependencies:
+    minimatch "3.0.4"
+    mockery "^1.7.0"
+    q "^1.1.2"
+    semver "^5.1.0"
+    shelljs "^0.3.0"
+    uuid "^3.0.1"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -272,17 +284,6 @@ uuid@^3.0.1:
 vsts-task-lib@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz#db8da359506160b944d4b5b33bdfbd1592076576"
-  dependencies:
-    minimatch "3.0.4"
-    mockery "^1.7.0"
-    q "^1.1.2"
-    semver "^5.1.0"
-    shelljs "^0.3.0"
-    uuid "^3.0.1"
-
-vsts-task-lib@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vsts-task-lib/-/vsts-task-lib-2.7.0.tgz#742973d2e9d6ad2fc30b732061088cdb6c7d2709"
   dependencies:
     minimatch "3.0.4"
     mockery "^1.7.0"

--- a/Tasks/Yarn/yarnTask.ts
+++ b/Tasks/Yarn/yarnTask.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as fs from "fs-extra";
-import * as tl from "vsts-task-lib/task";
-import * as tr from "vsts-task-lib/toolrunner";
+import * as tl from "azure-pipelines-task-lib/task";
+import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as q from "q";
 import * as npmutil from "./packaging/npm/npmutil";
 import * as util from "./packaging/util";

--- a/Tasks/YarnInstaller/package.json
+++ b/Tasks/YarnInstaller/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "ini": "^1.3.4",
-    "fs-extra": "7.0.1",
-    "vsts-task-lib": "2.7.0",
-    "vsts-task-tool-lib": "0.10.0",
-    "yog-tar.gz": "0.1.3",
+    "azure-pipelines-task-lib": "^2.8.0",
+    "azure-pipelines-tool-lib": "^0.12.0",
     "follow-redirects": "1.6.1",
-    "q": "^1.5.0"
+    "fs-extra": "7.0.1",
+    "ini": "^1.3.4",
+    "q": "^1.5.0",
+    "yog-tar.gz": "0.1.3"
   }
 }

--- a/Tasks/YarnInstaller/util.ts
+++ b/Tasks/YarnInstaller/util.ts
@@ -1,7 +1,7 @@
 let https = require("follow-redirects").https;
 import fs = require("fs");
 import q = require("q");
-import * as tl from "vsts-task-lib/task";
+import * as tl from "azure-pipelines-task-lib/task";
 import * as path from "path";
 import { IncomingMessage } from "http";
 let targz = require("yog-tar.gz");

--- a/Tasks/YarnInstaller/yarn.lock
+++ b/Tasks/YarnInstaller/yarn.lock
@@ -16,6 +16,31 @@
   dependencies:
     "@types/node" "*"
 
+azure-pipelines-task-lib@^2.8.0:
+  version "2.8.0"
+  resolved "https://www.myget.org/F/gl-unstable/npm/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz#8a0117a98f86c2e9ee85333e649874bf83ccb836"
+  integrity sha1-igEXqY+GwunuhTM+ZJh0v4PMuDY=
+  dependencies:
+    minimatch "3.0.4"
+    mockery "^1.7.0"
+    q "^1.1.2"
+    semver "^5.1.0"
+    shelljs "^0.3.0"
+    uuid "^3.0.1"
+
+azure-pipelines-tool-lib@^0.12.0:
+  version "0.12.0"
+  resolved "https://www.myget.org/F/gl-unstable/npm/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz#50fc45d7f4768f8fdf7503c7e74c1261f29a63d5"
+  integrity sha1-UPxF1/R2j4/fdQPH50wSYfKaY9U=
+  dependencies:
+    "@types/semver" "^5.3.0"
+    "@types/uuid" "^3.0.1"
+    azure-pipelines-task-lib "^2.8.0"
+    semver "^5.3.0"
+    semver-compare "^1.0.0"
+    typed-rest-client "1.0.9"
+    uuid "^3.0.1"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -193,9 +218,10 @@ tunnel@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.4.tgz#2d3785a158c174c9a16dc2c046ec5fc5f1742213"
 
-typed-rest-client@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.0.7.tgz#0eba935a93b1ca8800bafa0b4605397ff8211c70"
+typed-rest-client@1.0.9:
+  version "1.0.9"
+  resolved "https://www.myget.org/F/gl-unstable/npm/typed-rest-client/-/typed-rest-client-1.0.9.tgz#5317b607c9c8ee425b64260c9249d400d0a6bf1a"
+  integrity sha1-Uxe2B8nI7kJbZCYMkknUANCmvxo=
   dependencies:
     tunnel "0.0.4"
     underscore "1.8.3"
@@ -211,40 +237,6 @@ universalify@^0.1.0:
 uuid@^3.0.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-
-vsts-task-lib@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz#db8da359506160b944d4b5b33bdfbd1592076576"
-  dependencies:
-    minimatch "3.0.4"
-    mockery "^1.7.0"
-    q "^1.1.2"
-    semver "^5.1.0"
-    shelljs "^0.3.0"
-    uuid "^3.0.1"
-
-vsts-task-lib@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vsts-task-lib/-/vsts-task-lib-2.7.0.tgz#742973d2e9d6ad2fc30b732061088cdb6c7d2709"
-  dependencies:
-    minimatch "3.0.4"
-    mockery "^1.7.0"
-    q "^1.1.2"
-    semver "^5.1.0"
-    shelljs "^0.3.0"
-    uuid "^3.0.1"
-
-vsts-task-tool-lib@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/vsts-task-tool-lib/-/vsts-task-tool-lib-0.10.0.tgz#2c286364193c942808b94990a641a3f33b6cb1f8"
-  dependencies:
-    "@types/semver" "^5.3.0"
-    "@types/uuid" "^3.0.1"
-    semver "^5.3.0"
-    semver-compare "^1.0.0"
-    typed-rest-client "1.0.7"
-    uuid "^3.0.1"
-    vsts-task-lib "2.4.0"
 
 wrappy@1:
   version "1.0.2"

--- a/Tasks/YarnInstaller/yarnToolInstallerTask.ts
+++ b/Tasks/YarnInstaller/yarnToolInstallerTask.ts
@@ -1,8 +1,8 @@
 import fs = require("fs-extra");
 import q = require("q");
-import * as tl from "vsts-task-lib/task";
+import * as tl from "azure-pipelines-task-lib/task";
 import * as path from "path";
-import * as toolLib from "vsts-task-tool-lib/tool";
+import * as toolLib from "azure-pipelines-tool-lib/tool";
 import { downloadFile, getTempPath, detar } from "./util";
 
 let yarnVersionsFile = path.join(getTempPath(), "yarnVersions.json");


### PR DESCRIPTION
Removes
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr
(node:24124) Warning: Use Cipheriv for counter mode of aes-256-ctr