### PR TITLE
Proxy support

### DIFF
--- a/Tasks/YarnInstaller/download.ts
+++ b/Tasks/YarnInstaller/download.ts
@@ -1,11 +1,21 @@
 import * as https from "https";
+import * as HttpsProxyAgent from "https-proxy-agent";
 import q = require("q");
 import { IncomingMessage } from "http";
 
 function httpsGet(url: string): PromiseLike<IncomingMessage> {
   const deferal = q.defer<IncomingMessage>();
+
+  const options: https.RequestOptions = {};
+
+  var proxy = process.env.https_proxy;
+
+  if (proxy != null) {
+    options.agent = new HttpsProxyAgent(proxy);
+  }
+
   https
-    .get(url, (response: IncomingMessage) => {
+    .get(url, options, (response: IncomingMessage) => {
       deferal.resolve(response);
     })
     .on("error", (err: Error) => {

--- a/Tasks/YarnInstaller/package.json
+++ b/Tasks/YarnInstaller/package.json
@@ -6,6 +6,7 @@
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tool-lib": "^0.12.0",
     "fs-extra": "8.0.1",
+    "https-proxy-agent": "^2.2.1",
     "ini": "^1.3.5",
     "q": "^1.5.1",
     "tar": "4.4.9"

--- a/types/https-proxy-agent.d.ts
+++ b/types/https-proxy-agent.d.ts
@@ -1,0 +1,22 @@
+declare module "https-proxy-agent" {
+  import * as https from "https";
+
+  namespace HttpsProxyAgent {
+    interface HttpsProxyAgentOptions {
+      host: string;
+      port: number;
+      secureProxy?: boolean;
+      headers?: {
+        [key: string]: string;
+      };
+      [key: string]: any;
+    }
+  }
+
+  // HttpsProxyAgent doesnt *actually* extend https.Agent, but for my purposes I want it to pretend that it does
+  class HttpsProxyAgent extends https.Agent {
+    constructor(opts: HttpsProxyAgent.HttpsProxyAgentOptions | string);
+  }
+
+  export = HttpsProxyAgent;
+}


### PR DESCRIPTION
Hi!

These were the changes I needed to do to make the download test work behind a proxy. Hopefully it does not introduce new issues.

I did not try to run it via Azure DevOps.

Related to https://github.com/geeklearningio/gl-vsts-tasks-yarn/issues/59