### PR TITLE
Update Proxy Support to respect Azure DevOps upper case variable names

### DIFF
--- a/Tasks/YarnInstaller/download.ts
+++ b/Tasks/YarnInstaller/download.ts
@@ -8,9 +8,13 @@ function httpsGet(url: string): PromiseLike<IncomingMessage> {
 
   const options: https.RequestOptions = {};
 
-  var proxy = process.env.https_proxy;
+  var proxy = // Azure DevOps transforms all variables to uppercase
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
 
-  if (proxy != null) {
+  if (proxy !== null && proxy !== undefined) {
     options.agent = new HttpsProxyAgent(proxy);
   }
 


### PR DESCRIPTION
Hi all,

I found that #65 does in fact not work in Azure DevOps Pipelines.
(Re-)Fixes #59. 

As stated by the PR creator
> I did not try to run it via Azure DevOps.

Azure DevOps transforms all variables to uppercase, so we have to check for uppercase proxy variables.

See [here (StackOverflow)](https://stackoverflow.com/questions/52175384/how-to-set-variable-name-in-lowercase-on-vsts-ci-in-vsts-ci-yml) and [here (VS Developer Community)](https://developercommunity.visualstudio.com/content/problem/328064/vsts-silently-converts-variable-names-to-uppercase.html).

Additionally I added a check for `undefined`, since undefined process.env.VARIABLE is, well `undefined`:

```
$ node
> process.env.http_proxy
'http://127.0.0.1:3128/'
> process.env.obviously_undefined_env_var //
undefined
> 
```